### PR TITLE
Fix timezone aware insertion in save_online_history_task

### DIFF
--- a/bot/updater.py
+++ b/bot/updater.py
@@ -218,7 +218,9 @@ async def save_online_history_task(bot: discord.Client) -> None:
                         xml = await fetch_dedicated_server_stats_cached(session)
                         players = parse_players_online(xml) if xml else []
                         log_debug(f"[ONLINE] Игроки онлайн: {players}")
-                        records = [(name, now) for name in players]
+                        records = [
+                            (name, now.replace(tzinfo=None)) for name in players
+                        ]
                         if records:
                             try:
                                 await bot.db_pool.executemany(


### PR DESCRIPTION
## Summary
- fix player online history insertion with timezone-aware datetimes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6873b96da59c832b87a6f5bab8d0d5fa