### PR TITLE
Ensure ftp polling updates every interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
 - `DISCORD_TOKEN` — токен Discord-бота
 - `DISCORD_CHANNEL_ID` — ID канала для обновления сообщения
 - `API_POLL_INTERVAL` — интервал опроса API (сек)
-- `FTP_POLL_INTERVAL` — интервал опроса FTP (сек)
+- `FTP_POLL_INTERVAL` — интервал опроса FTP (сек). Сообщение обновляется
+  каждый раз при выполнении этого цикла.
 - `API_BASE_URL` — базовый URL API
 - `API_SECRET_CODE` — секретный код API
 - `FTP_HOST` — адрес FTP-сервера


### PR DESCRIPTION
## Summary
- change `ftp_polling_task` to remove the old day time check and always send the updated discord message
- update the task docstring and README to describe the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873e8a55f24832bbb4e5d28800f15e8