### PR TITLE
Fix total time accumulation

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -14,7 +14,8 @@ CREATE INDEX IF NOT EXISTS idx_online_check_time ON player_online_history (check
 CREATE TABLE IF NOT EXISTS player_total_time (
     player_name TEXT PRIMARY KEY,
     total_hours INTEGER NOT NULL,
-    updated_at TIMESTAMP NOT NULL
+    updated_at TIMESTAMP NOT NULL,
+    last_timestamp TIMESTAMP NOT NULL DEFAULT 'epoch'
 );
 -- Индекс для сортировки по общему времени
 CREATE INDEX IF NOT EXISTS idx_total_hours ON player_total_time (total_hours DESC);


### PR DESCRIPTION
## Summary
- preserve total play time when history is cleaned
- add `last_timestamp` column to `player_total_time`

## Testing
- `python -m py_compile utils/total_time_updater.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68752e42f790832b924f17f36c630f5c