### PR TITLE
Fix SQL parameterization

### DIFF
--- a/bot/updater.py
+++ b/bot/updater.py
@@ -246,7 +246,9 @@ async def cleanup_old_online_history_task(bot: discord.Client) -> None:
         try:
             log_debug("[DB] Удаляем старые записи из player_online_history")
             await bot.db_pool.execute(
-                f"DELETE FROM player_online_history WHERE check_time < NOW() - INTERVAL '{cleanup_history_days} days'"
+                "DELETE FROM player_online_history "
+                "WHERE check_time < NOW() - $1 * INTERVAL '1 day'",
+                cleanup_history_days,
             )
             await asyncio.sleep(cleanup_task_interval_seconds)
         except asyncio.CancelledError:


### PR DESCRIPTION
## Summary
- use placeholders instead of f-string interpolation in `cleanup_old_online_history_task`
- build weekly archive queries with `asyncpg.sql` for safe table name insertion

## Testing
- `python -m py_compile bot/updater.py utils/weekly_archiver.py`

------
https://chatgpt.com/codex/tasks/task_e_68752e52380c832b89f7449803b1d092