### PR TITLE
Fix asyncpg sql import

### DIFF
--- a/utils/weekly_archiver.py
+++ b/utils/weekly_archiver.py
@@ -6,7 +6,8 @@ import asyncio
 from datetime import timedelta, datetime
 from typing import List, Tuple
 
-from asyncpg import Pool, sql
+from asyncpg import Pool
+from asyncpg.sql import SQL, Identifier
 
 from config.config import (
     WEEKLY_TOP_LIMIT,
@@ -73,27 +74,27 @@ async def archive_weekly_top(
         async with db_pool.acquire() as conn:
             async with conn.transaction():
                 await conn.execute(
-                    sql.SQL(
+                    SQL(
                         """
                         CREATE TABLE IF NOT EXISTS {} (
                             player_name TEXT PRIMARY KEY,
                             hours INTEGER NOT NULL
                         )
                         """
-                    ).format(sql.Identifier(table_name))
+                    ).format(Identifier(table_name))
                 )
                 await conn.execute(
-                    sql.SQL("TRUNCATE TABLE {}" ).format(sql.Identifier(table_name))
+                    SQL("TRUNCATE TABLE {}" ).format(Identifier(table_name))
                 )
                 await conn.executemany(
-                    sql.SQL(
+                    SQL(
                         """
                         INSERT INTO {} (player_name, hours)
                         VALUES ($1, $2)
                         ON CONFLICT (player_name) DO UPDATE
                         SET hours = EXCLUDED.hours
                         """
-                    ).format(sql.Identifier(table_name)),
+                    ).format(Identifier(table_name)),
                     rows,
                 )
         log_debug("[ARCHIVER] Топ игроков сохранён")


### PR DESCRIPTION
## Summary
- fix incorrect asyncpg `sql` import in weekly_archiver

## Testing
- `python -m compileall -q -f .`


------
https://chatgpt.com/codex/tasks/task_e_68755b373bac832b9bb73ed5ba43f2df