### PR TITLE
Fix Postgres queries for graph and total time

### DIFF
--- a/utils/online_daily_graph.py
+++ b/utils/online_daily_graph.py
@@ -24,7 +24,11 @@ async def fetch_daily_online_counts(db_pool) -> List[int]:
         rows = await db_pool.fetch(
             """
             WITH hours AS (
-                SELECT generate_series($1, $1 + interval '23 hours', interval '1 hour') AS hour_start
+                SELECT generate_series(
+                    $1::timestamp,
+                    $1::timestamp + interval '23 hours',
+                    '1 hour'::interval
+                ) AS hour_start
             ),
             slice_counts AS (
                 SELECT date_trunc('hour', check_time) AS hour_start,

--- a/utils/total_time_updater.py
+++ b/utils/total_time_updater.py
@@ -51,6 +51,17 @@ async def update_total_time(
     try:
         async with db_pool.acquire() as conn:
             async with conn.transaction():
+                # Создаём таблицу, если её ещё нет (нужен PRIMARY KEY для ON CONFLICT)
+                await conn.execute(
+                    f"""
+                    CREATE TABLE IF NOT EXISTS {total_table} (
+                        player_name TEXT PRIMARY KEY,
+                        total_hours INTEGER NOT NULL,
+                        updated_at TIMESTAMP NOT NULL,
+                        last_timestamp TIMESTAMP NOT NULL DEFAULT 'epoch'
+                    )
+                    """
+                )
                 await conn.execute(
                     f"ALTER TABLE {total_table} "
                     "ADD COLUMN IF NOT EXISTS last_timestamp TIMESTAMP NOT NULL DEFAULT 'epoch'"


### PR DESCRIPTION
## Summary
- cast args for `generate_series` to avoid type errors
- ensure total time table exists with primary key before using ON CONFLICT

## Testing
- `python -m py_compile utils/online_daily_graph.py utils/total_time_updater.py`

------
https://chatgpt.com/codex/tasks/task_e_687569533b20832b9ea2e66c89a539d1