### PR TITLE
Add export Excel command

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ from commands.top7lastweek import setup as setup_top7lastweek
 from commands.top7week import setup as setup_top7week
 from commands.top_total import setup as setup_top_total
 from commands.online_month import setup as setup_online_month
+from commands.export_excel import setup as setup_export_excel
 
 
 def handle_task_exception(task: asyncio.Task) -> None:
@@ -102,6 +103,7 @@ class MyBot(discord.Client):
 
         setup_top_total(self.tree)
         setup_online_month(self.tree)
+        await setup_export_excel(self.tree)
         await self.tree.sync()
         log_debug("[SYNC] Slash-команды успешно синхронизированы")
         log_debug("[Slash] Команды синхронизированы")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ asyncpg>=0.27
 discord.py>=2.3
 matplotlib>=3.5
 python-dotenv>=0.21
+openpyxl>=3.1


### PR DESCRIPTION
## Summary
- add `/экспорт_excel` command to export players to Excel
- register the command in bot setup
- add openpyxl dependency

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile commands/export_excel.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_689017a87388832b949cd9bd8ddcf770