### PR TITLE
Add export Excel command

### DIFF
--- a/commands/export_excel.py
+++ b/commands/export_excel.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import io
+import os
+from datetime import datetime
+from typing import List, Tuple
+
+import discord
+from discord import app_commands
+from asyncpg import Pool
+from openpyxl import Workbook
+
+from utils.logger import log_debug
+
+
+async def fetch_players(pool: Pool) -> List[Tuple[str, float, datetime]]:
+    """Fetch all players sorted by total time."""
+    try:
+        rows = await pool.fetch(
+            """
+            SELECT player_name AS nickname,
+                   total_hours,
+                   updated_at AS last_seen
+            FROM player_total_time
+            ORDER BY total_hours DESC;
+            """
+        )
+    except Exception as e:
+        log_debug(f"[DB] export_excel fetch error: {e}")
+        raise
+    return [
+        (r["nickname"], float(r["total_hours"]), r["last_seen"])
+        for r in rows
+    ]
+
+
+async def _handle_command(interaction: discord.Interaction) -> None:
+    await interaction.response.defer()
+    pool: Pool = interaction.client.db_pool
+    try:
+        players = await fetch_players(pool)
+    except Exception:
+        await interaction.followup.send("Ошибка при получении данных.", ephemeral=True)
+        return
+
+    if not players:
+        await interaction.followup.send("Нет данных.")
+        return
+
+    try:
+        wb = Workbook()
+        ws = wb.active
+        ws.title = "Players"
+        ws.append(["Никнейм", "Общее время (ч)", "Последнее появление"])
+        ws.column_dimensions["A"].width = 25
+        ws.column_dimensions["B"].width = 15
+        ws.column_dimensions["C"].width = 30
+        date_fmt = "%d.%m.%Y %H:%M:%S"
+        for nickname, total_time, last_seen in players:
+            ws.append([nickname, total_time, last_seen.strftime(date_fmt)])
+
+        buffer = io.BytesIO()
+        wb.save(buffer)
+        buffer.seek(0)
+    except Exception as e:
+        log_debug(f"[CMD] export_excel build error: {e}")
+        await interaction.followup.send("Ошибка при формировании файла.", ephemeral=True)
+        return
+
+    filename = os.path.join("", "players.xlsx")
+    try:
+        await interaction.followup.send(
+            file=discord.File(buffer, filename=filename)
+        )
+    except Exception as e:
+        log_debug(f"[CMD] export_excel send error: {e}")
+        await interaction.followup.send("Ошибка при отправке файла.", ephemeral=True)
+
+
+async def setup(tree: app_commands.CommandTree) -> None:
+    @tree.command(name="экспорт_excel", description="Экспорт данных игроков в Excel")
+    async def export_excel_command(interaction: discord.Interaction) -> None:
+        await _handle_command(interaction)
+
+    log_debug("[Slash] Команда /экспорт_excel зарегистрирована")

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ from commands.top7lastweek import setup as setup_top7lastweek
 from commands.top7week import setup as setup_top7week
 from commands.top_total import setup as setup_top_total
 from commands.online_month import setup as setup_online_month
+from commands.export_excel import setup as setup_export_excel
 
 
 def handle_task_exception(task: asyncio.Task) -> None:
@@ -102,6 +103,7 @@ class MyBot(discord.Client):
 
         setup_top_total(self.tree)
         setup_online_month(self.tree)
+        await setup_export_excel(self.tree)
         await self.tree.sync()
         log_debug("[SYNC] Slash-команды успешно синхронизированы")
         log_debug("[Slash] Команды синхронизированы")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ asyncpg>=0.27
 discord.py>=2.3
 matplotlib>=3.5
 python-dotenv>=0.21
+openpyxl>=3.1


### PR DESCRIPTION
## Summary
- add `/экспорт_excel` command to export players to Excel
- register the command in bot setup
- add openpyxl dependency
- query player_total_time table for total_hours in export

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile commands/export_excel.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_689017a87388832b949cd9bd8ddcf770