### PR TITLE
Prevent decreasing total play time

### DIFF
--- a/utils/total_time_updater.py
+++ b/utils/total_time_updater.py
@@ -71,7 +71,7 @@ async def update_total_time(
                         INSERT INTO {total_table} (player_name, total_hours, updated_at)
                         VALUES ($1, $2, NOW())
                         ON CONFLICT (player_name) DO UPDATE
-                            SET total_hours = EXCLUDED.total_hours,
+                            SET total_hours = GREATEST(player_total_time.total_hours, EXCLUDED.total_hours),
                                 updated_at = EXCLUDED.updated_at
                         """,
                         rows,


### PR DESCRIPTION
## Summary
- keep `total_hours` from decreasing by using `GREATEST` in UPSERT

## Testing
- `python -m py_compile utils/total_time_updater.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890d7cebdc8832b91c9c8a722518d58