### PR TITLE
feat: incrementally update player total time

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -14,7 +14,8 @@ CREATE INDEX IF NOT EXISTS idx_online_check_time ON player_online_history (check
 CREATE TABLE IF NOT EXISTS player_total_time (
     id SERIAL PRIMARY KEY,
     player_name TEXT UNIQUE NOT NULL,
-    total_hours INTEGER NOT NULL,
+    total_hours INTEGER NOT NULL DEFAULT 0,
+    last_processed_at TIMESTAMP NOT NULL DEFAULT '2000-01-01 00:00:00',
     updated_at TIMESTAMP NOT NULL
 );
 -- Индекс для сортировки по общему времени


### PR DESCRIPTION
## Summary
- default total_hours to 0 and track last processed hour
- initialize new player records to current time and skip past hours
- batch update total_hours using CTE to add only fresh hours after last_processed_at

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890dc5c24fc832b9a0cd6e31e1a1d42