### PR TITLE
Add last update column to Excel export

### DIFF
--- a/commands/export_excel.py
+++ b/commands/export_excel.py
@@ -52,14 +52,17 @@ async def _handle_command(interaction: discord.Interaction) -> None:
         wb = Workbook()
         ws = wb.active
         ws.title = "Players"
-        ws.append(["Никнейм", "Общее время (ч)"])
+        ws.append(["Никнейм", "Общее время (ч)", "Последнее обновление"])
         ws.column_dimensions["A"].width = 25
         ws.column_dimensions["B"].width = 15
-        for nickname, total_time, _ in players:
-            ws.append([nickname, total_time])
+        ws.column_dimensions["C"].width = 20
+        for nickname, total_time, last_seen in players:
+            formatted_last_seen = last_seen.strftime("%d.%m.%Y %H:%M")
+            ws.append([nickname, total_time, formatted_last_seen])
 
-        for row in ws.iter_rows(min_row=2, max_col=2, max_row=ws.max_row):
+        for row in ws.iter_rows(min_row=2, max_col=3, max_row=ws.max_row):
             row[1].alignment = Alignment(horizontal="center")
+            row[2].alignment = Alignment(horizontal="center")
 
         buffer = io.BytesIO()
         wb.save(buffer)


### PR DESCRIPTION
## Summary
- export players with last update date column formatted as `dd.mm.yyyy HH:MM`

## Testing
- `python -m py_compile commands/export_excel.py`


------
https://chatgpt.com/codex/tasks/task_e_6890e26d9fc0832ba11cf245675dd63b