### PR TITLE
Add command to clear bot messages

### DIFF
--- a/commands/clear_bot_messages.py
+++ b/commands/clear_bot_messages.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import discord
+from discord import app_commands
+
+from utils.logger import log_debug
+
+
+async def _clear_messages(interaction: discord.Interaction) -> None:
+    """Delete all messages sent by this bot in the current channel."""
+    await interaction.response.defer(ephemeral=True)
+
+    channel = interaction.channel
+    bot_user = interaction.client.user
+    if channel is None or bot_user is None:
+        await interaction.followup.send("Не удалось получить канал или бота.", ephemeral=True)
+        return
+
+    deleted = 0
+    try:
+        async for message in channel.history(limit=None):
+            if message.author.id == bot_user.id:
+                try:
+                    await message.delete()
+                    deleted += 1
+                except discord.Forbidden:
+                    await interaction.followup.send(
+                        "Нет прав на удаление сообщений.", ephemeral=True
+                    )
+                    return
+                except discord.HTTPException as e:
+                    log_debug(f"[CMD] clear_bot_messages delete error: {e}")
+    except discord.Forbidden:
+        await interaction.followup.send(
+            "Нет прав на чтение истории сообщений.", ephemeral=True
+        )
+        return
+    except Exception as e:  # pragma: no cover - unexpected errors
+        log_debug(f"[CMD] clear_bot_messages error: {e}")
+        await interaction.followup.send(
+            "Произошла ошибка при удалении сообщений.", ephemeral=True
+        )
+        return
+
+    if deleted == 0:
+        await interaction.followup.send(
+            "Нет сообщений для удаления", ephemeral=True
+        )
+    else:
+        await interaction.followup.send(
+            f"Удалено сообщений: {deleted}", ephemeral=True
+        )
+
+
+def setup(tree: app_commands.CommandTree) -> None:
+    @tree.command(
+        name="clear_bot_messages",
+        description="Удаляет сообщения, отправленные ботом в текущем канале",
+    )
+    async def clear_bot_messages(interaction: discord.Interaction) -> None:
+        await _clear_messages(interaction)
+
+    log_debug("[Slash] Команда /clear_bot_messages зарегистрирована")

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from commands.top_total import setup as setup_top_total
 from commands.online_month import setup as setup_online_month
 from commands.export_excel import setup as setup_export_excel
 from commands.info import setup as setup_info
+from commands.clear_bot_messages import setup as setup_clear_bot_messages
 
 
 def handle_task_exception(task: asyncio.Task) -> None:
@@ -105,6 +106,7 @@ class MyBot(discord.Client):
         setup_top_total(self.tree)
         setup_online_month(self.tree)
         setup_info(self.tree)
+        setup_clear_bot_messages(self.tree)
         await setup_export_excel(self.tree)
         await self.tree.sync()
         log_debug("[SYNC] Slash-команды успешно синхронизированы")


### PR DESCRIPTION
## Summary
- add /clear_bot_messages slash command to delete bot's messages in a channel
- register command with the bot's command tree

## Testing
- `python -m py_compile main.py commands/clear_bot_messages.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68916003cd84832babe0000526abb0f6