### PR TITLE
Add pause guard for slash commands

### DIFF
--- a/commands/clear_bot_messages.py
+++ b/commands/clear_bot_messages.py
@@ -4,6 +4,7 @@ import discord
 from discord import app_commands
 
 from utils.logger import log_debug
+from pause_guard import pause_guard
 
 
 async def _clear_messages(interaction: discord.Interaction) -> None:
@@ -57,6 +58,7 @@ def setup(tree: app_commands.CommandTree) -> None:
         name="clear_bot_messages",
         description="Удаляет сообщения, отправленные ботом в текущем канале",
     )
+    @pause_guard
     async def clear_bot_messages(interaction: discord.Interaction) -> None:
         await _clear_messages(interaction)
 

--- a/commands/export_excel.py
+++ b/commands/export_excel.py
@@ -12,6 +12,7 @@ from openpyxl import Workbook
 from openpyxl.styles import Alignment
 
 from utils.logger import log_debug
+from pause_guard import pause_guard
 
 
 async def fetch_players(pool: Pool) -> List[Tuple[str, float, datetime]]:
@@ -84,6 +85,7 @@ async def _handle_command(interaction: discord.Interaction) -> None:
 
 async def setup(tree: app_commands.CommandTree) -> None:
     @tree.command(name="экспорт_excel", description="Экспорт данных игроков в Excel")
+    @pause_guard
     async def export_excel_command(interaction: discord.Interaction) -> None:
         await _handle_command(interaction)
 

--- a/commands/info.py
+++ b/commands/info.py
@@ -4,6 +4,7 @@ import discord
 from discord import app_commands
 
 from utils.logger import log_debug
+from pause_guard import pause_guard
 
 INFO_TEXT = (
     "\U0001f4ca Информация о боте статистики активности\n"
@@ -38,6 +39,7 @@ INFO_TEXT = (
 
 def setup(tree: app_commands.CommandTree) -> None:
     @tree.command(name="info", description="Информация о том, как работает бот")
+    @pause_guard
     async def info_command(interaction: discord.Interaction) -> None:
         await interaction.response.send_message(INFO_TEXT)
 

--- a/commands/online_month.py
+++ b/commands/online_month.py
@@ -8,6 +8,7 @@ from discord import app_commands
 from config.config import ONLINE_MONTH_GRAPH_TITLE
 from utils.online_month_graph import generate_online_month_graph
 from utils.logger import log_debug
+from pause_guard import pause_guard
 
 
 def setup(tree: app_commands.CommandTree) -> None:
@@ -15,6 +16,7 @@ def setup(tree: app_commands.CommandTree) -> None:
         name="online_month",
         description="График онлайна по дням за последние 30 дней",
     )
+    @pause_guard
     async def online_month_command(interaction: discord.Interaction) -> None:
         await interaction.response.defer()
         try:

--- a/commands/top7lastweek.py
+++ b/commands/top7lastweek.py
@@ -7,6 +7,7 @@ from asyncpg import Pool
 
 from config.config import WEEKLY_TOP_LIMIT, WEEKLY_TOP_LAST_TABLE
 from utils.logger import log_debug
+from pause_guard import pause_guard
 
 
 async def _fetch_last_week_top(
@@ -62,6 +63,7 @@ def setup(
     limit: int = WEEKLY_TOP_LIMIT,
 ) -> None:
     @tree.command(name="top7lastweek", description="Топ игроков прошлой недели")
+    @pause_guard
     async def top7lastweek_command(interaction: discord.Interaction) -> None:
         await _handle_command(interaction, table_name=table_name, limit=limit)
 

--- a/commands/top7week.py
+++ b/commands/top7week.py
@@ -5,10 +5,12 @@ from discord import app_commands
 
 from utils.weekly_top import generate_weekly_top
 from utils.logger import log_debug
+from pause_guard import pause_guard
 
 
 def setup(tree: app_commands.CommandTree) -> None:
     @tree.command(name="top7week", description="Топ 7 игроков за неделю по часам")
+    @pause_guard
     async def top7week_command(interaction: discord.Interaction) -> None:
         await interaction.response.defer()
         try:

--- a/commands/top_total.py
+++ b/commands/top_total.py
@@ -6,6 +6,7 @@ from discord import app_commands
 from asyncpg import Pool
 
 from utils.logger import log_debug
+from pause_guard import pause_guard
 from config.config import TOTAL_TOP_LIMIT, TOTAL_TOP_TABLE
 
 
@@ -77,6 +78,7 @@ def setup(
     limit: int = TOTAL_TOP_LIMIT,
 ) -> None:
     @tree.command(name="top_total", description="Топ игроков по общему времени")
+    @pause_guard
     async def top_total_command(interaction: discord.Interaction) -> None:
         await _handle_command(interaction, table_name=table_name, limit=limit)
 

--- a/pause_guard.py
+++ b/pause_guard.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Decorator to block slash commands when the bot is paused."""
+
+from functools import wraps
+from typing import Any, Awaitable, Callable, TypeVar, cast
+
+import discord
+
+from config.config import config
+
+PAUSE_MESSAGE = "\U0001f6d1 Сервер находится в режиме паузы. Команды временно недоступны."
+
+F = TypeVar("F", bound=Callable[..., Awaitable[None]])
+
+
+def pause_guard(func: F) -> F:
+    """Prevent command execution if bot is paused."""
+
+    @wraps(func)
+    async def wrapper(*args: Any, **kwargs: Any) -> None:
+        interaction: discord.Interaction | None = None
+        if args:
+            interaction = cast(discord.Interaction, args[0])
+        elif "interaction" in kwargs:
+            interaction = cast(discord.Interaction, kwargs["interaction"])
+        if config.bot_paused_mode and interaction is not None:
+            if interaction.response.is_done():
+                await interaction.followup.send(PAUSE_MESSAGE, ephemeral=True)
+            else:
+                await interaction.response.send_message(PAUSE_MESSAGE, ephemeral=True)
+            return
+        await func(*args, **kwargs)
+
+    return cast(F, wrapper)


### PR DESCRIPTION
## Summary
- centralize paused-mode handling via typed `pause_guard` decorator
- update all slash commands to import and use `pause_guard`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892aa438124832b9daf1775ffcecec8